### PR TITLE
TRACE-171 Add logic to existing scripts to remove config contaiers

### DIFF
--- a/docker/compose.sh
+++ b/docker/compose.sh
@@ -35,7 +35,8 @@ elif [ "$1" == "destroy" ]; then
     read -p ">> " destroy
 
     if [[ "$destroy" =~ ^(y|Y)$ ]]; then
-        docker-compose -f "$composeFilePath"/docker-compose-services.yml -f "$composeFilePath"/docker-compose-apps.yml -f "$composeFilePath"/docker-compose-dbs.yml down -v
+        ./docker/import-export.sh destroy all
+        docker-compose -f "$composeFilePath"/docker-compose-services.yml -f "$composeFilePath"/docker-compose-apps.yml -f "$composeFilePath"/docker-compose-dbs.yml -f "$composeFilePath"/default/docker-compose-config.yml down -v
     fi
 else
     echo "Valid options are: init, up, down, or destroy"

--- a/docker/import-export.sh
+++ b/docker/import-export.sh
@@ -61,6 +61,32 @@ elif [ "$COMMAND" == "export" ]; then
     if [[ "$TARGET" =~ ^(facility-cache|all)$ ]]; then
         echo "No export option yet for the Faciliy Cache Mediator"
     fi
+elif [ "$COMMAND" == "destroy" ]; then
+    if [[ "$TARGET" =~ ^(dhis2|all)$ ]]; then
+        docker-compose -f "$composeFilePath"/import-export/dhis2/docker-compose.exporter.dhis2.yml down -v
+        docker-compose -f "$composeFilePath"/import-export/dhis2/docker-compose.importer.dhis2.yml down -v
+    fi
+
+    if [[ "$TARGET" =~ ^(openhim|all)$ ]]; then
+        docker-compose -f "$composeFilePath"/import-export/openhim/docker-compose.exporter.openhim.yml down -v
+        docker-compose -f "$composeFilePath"/import-export/openhim/docker-compose.importer.openhim.yml down -v
+    fi
+
+    if [[ "$TARGET" =~ ^(validator-orchestrator|all)$ ]]; then
+        docker-compose -f "$composeFilePath"/import-export/validator-orchestrator/docker-compose.importer.validator-orchestrator.yml down -v
+    fi
+
+    if [[ "$TARGET" =~ ^(populator|all)$ ]]; then
+        docker-compose -f "$composeFilePath"/import-export/populator/docker-compose.importer.populator.yml down -v
+    fi
+
+    if [[ "$TARGET" =~ ^(file-queue|all)$ ]]; then
+        docker-compose -f "$composeFilePath"/import-export/file-queue/docker-compose.importer.file-queue.yml down -v
+    fi
+
+    if [[ "$TARGET" =~ ^(facility-cache|all)$ ]]; then
+        docker-compose -f "$composeFilePath"/import-export/facility-cache/docker-compose.importer.facility-cache.yml down -v
+    fi
 else
-    echo "Valid command options are: import or export"
+    echo "Valid command options are: import, export, or destroy"
 fi


### PR DESCRIPTION
These containers were not cleaned up with any previous script. This left
them behind after the rest of the system was removed.
This is an issue for two reasons:
Firstly, the containers were attached to the docker network of the
larger system. This prevents the network from being cleaned up on system
destroy as tehre are containers using it. If the system is restarted the
existing containers won't be able to communicate on the new network as
they are already assigned on the old network. This will throw errors on
config container restart.
Second, these containers do take a bit of space, therefore when they are
no longer needed it would be best to remove them completely.

TRACE-171