### PR TITLE
The file queue should be exposed on port 4002

### DIFF
--- a/docker/docker-compose-services.yml
+++ b/docker/docker-compose-services.yml
@@ -40,7 +40,6 @@ services:
       - HEARTBEAT=true
       - LOG_LEVEL=info
       - NODE_TLS_REJECT_UNAUTHORIZED=0
-      - SERVER_PORT=4003
       - TRUST_SELF_SIGNED=true
     volumes:
       - ./file-queue-mediator.json:/opt/openhim-mediator-file-queue/config/mediator.json

--- a/docker/import-export/validator-orchestrator/volume/inpatient-admissions.json
+++ b/docker/import-export/validator-orchestrator/volume/inpatient-admissions.json
@@ -87,7 +87,7 @@
         "id": "dhis-event",
         "config": {
           "method": "post",
-          "url": "http://file-queue:4003/tracker-event"
+          "url": "http://file-queue:4002/tracker-event"
         }
       }
     ]


### PR DESCRIPTION
It was originially setto 4003, but when switch to 4002, the 4003 env var
was not removed from the startup script

TRACE-157