### PR TITLE
Updated to newer OpenHIM console

### DIFF
--- a/docker/docker-compose-apps.yml
+++ b/docker/docker-compose-apps.yml
@@ -33,7 +33,7 @@ services:
 
   openhim-console:
     container_name: openhim-console
-    image: jembi/openhim-console:1.13
+    image: jembi/openhim-console:1.14
     ports:
       - "9000:80"
     depends_on:


### PR DESCRIPTION
So that we make use of the enw auth features within the new OpenHIM core/console
OpenHIM core is already on 5 so nothing needs to change.